### PR TITLE
Change mongo package

### DIFF
--- a/examples/go-json-rest/main.go
+++ b/examples/go-json-rest/main.go
@@ -11,7 +11,7 @@ import (
     "github.com/ant0ine/go-json-rest/rest"
     "github.com/gorilla/context"
     "github.com/gorilla/mux"
-    "labix.org/v2/mgo"
+    "gopkg.in/mgo.v2"
 )
 
 func main() {

--- a/examples/go-json-rest/oauth.go
+++ b/examples/go-json-rest/oauth.go
@@ -4,8 +4,8 @@ import (
     "fmt"
     "net/http"
 
-    "labix.org/v2/mgo"
-    "labix.org/v2/mgo/bson"
+    "gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
 
     "github.com/RangelReale/osin"
     "github.com/RangelReale/osin/example"

--- a/mgostore/mgostorage.go
+++ b/mgostore/mgostorage.go
@@ -4,8 +4,8 @@ import (
     "github.com/RangelReale/osin"
 
 	"encoding/json"
-    "labix.org/v2/mgo"
-    "labix.org/v2/mgo/bson"
+    "gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
 )
 
 // collection names for the entities

--- a/mgostore/mgostorage_test.go
+++ b/mgostore/mgostorage_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/RangelReale/osin"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 var session *mgo.Session


### PR DESCRIPTION
According to this git commit, this package was
officially moved to the gopkg repository.

go-mgo/mgo@d1fb2c3
https://blog.labix.org/2014/07/21/mgo-release-r2014-07-21-now-at-gopkg-in